### PR TITLE
Match tuples and atoms

### DIFF
--- a/lib/norm/conformer.ex
+++ b/lib/norm/conformer.ex
@@ -11,6 +11,19 @@ defmodule Norm.Conformer do
     end
   end
 
+  def group_results(results) do
+    results
+    |> Enum.reduce(%{ok: [], error: []}, fn {result, s}, acc ->
+      Map.put(acc, result, acc[result] ++ [s])
+    end)
+    |> update_in([:ok], & List.flatten(&1))
+    |> update_in([:error], & List.flatten(&1))
+  end
+
+  def error(path, input, msg) do
+    %{path: path, input: input, msg: msg, at: nil}
+  end
+
   def error_to_msg(%{path: path, input: input, msg: msg}) do
     path  = if path == [], do: nil, else: "in: " <> build_path(path)
     val   = "val: #{format_val(input)}"
@@ -33,6 +46,7 @@ defmodule Norm.Conformer do
   defp format_val(msg) when is_atom(msg), do: ":#{msg}"
   defp format_val(val) when is_map(val), do: inspect val
   defp format_val({:index, i}), do: "[#{i}]"
+  defp format_val(t) when is_tuple(t), do: "#{inspect t}"
   defp format_val(msg), do: "#{msg}"
 
 

--- a/lib/norm/spec.ex
+++ b/lib/norm/spec.ex
@@ -5,7 +5,9 @@ defmodule Norm.Spec do
   alias __MODULE__
   alias Norm.Spec.{
     And,
+    Atom,
     Or,
+    Tuple,
   }
 
   defstruct predicate: nil, generator: nil, f: nil
@@ -24,7 +26,28 @@ defmodule Norm.Spec do
     r = build(right)
 
     quote do
-      %And{left: unquote(l), right: unquote(r)}
+      And.new(unquote(l), unquote(r))
+    end
+  end
+
+  # 2-Tuple
+  def build({first, second}) do
+    quote do
+      %Tuple{args: [unquote(first), unquote(second)]}
+    end
+  end
+
+  # Tuples with more then 2 elements
+  def build({:{}, _, args}) do
+    quote do
+      %Tuple{args: unquote(args)}
+    end
+  end
+
+  # Bare atom's
+  def build(atom) when is_atom(atom) do
+    quote do
+      %Atom{atom: unquote(atom)}
     end
   end
 
@@ -92,249 +115,6 @@ defmodule Norm.Spec do
     end
   end
 
-  # def build(int) when is_integer(int) do
-  #   quote do
-  #     unquote(int)
-  #   end
-  # end
-
-  # def build({a, b}) do
-  #   IO.inspect([a, b], label: "Two Tuple")
-  #   l = build(a)
-  #   r = build(b)
-
-  #   quote do
-  #     %Tuple{args: [unquote(l), unquote(r)]}
-  #   end
-  # end
-
-  # def build({:{}, _, args}) do
-  #   args = Enum.map(args, &build/1)
-
-  #   quote do
-  #     %Tuple{args: unquote(args)}
-  #   end
-  # end
-
-  # @doc ~S"""
-  # """
-  # def lit(val) do
-  #   fn path, input ->
-  #     if input == val do
-  #       {:ok, input}
-  #     else
-  #       {:error, [error(path, input, format_val(val))]}
-  #     end
-  #   end
-  # end
-  # def string? do
-  #   fn path, input ->
-  #     if is_binary(input) do
-  #       {:ok, input}
-  #     else
-  #       {:error, [error(path, input, "string?()")]}
-  #     end
-  #   end
-  # end
-
-  # @doc ~S"""
-  # Ands together two specs.
-
-  # iex> conform(:atom, sand(string?(), lit("foo")))
-  # {:error, ["val: :atom fails: string?()", "val: :atom fails: \"foo\""]}
-  # iex> conform!("foo", sand(string?(), lit("foo")))
-  # "foo"
-  # """
-  # def sand(l, r) do
-  #   fn path, input ->
-  #     errors =
-  #       [l, r]
-  #       |> Enum.map(fn spec -> spec.(path, input) end)
-  #       |> Enum.filter(fn {result, _} -> result == :error end)
-  #       |> Enum.flat_map(fn {_, msg} -> msg end)
-
-  #     if Enum.any?(errors) do
-  #       {:error, errors}
-  #     else
-  #       {:ok, input}
-  #     end
-  #   end
-  # end
-
-  # @doc ~S"""
-  # Ors two specs together
-
-  # iex> conform!("foo", sor(string?(), integer?()))
-  # "foo"
-  # iex> conform!(1, sor(string?(), integer?()))
-  # 1
-  # iex> conform(:atom, sor(string?(), integer?()))
-  # {:error, ["val: :atom fails: string?()", "val: :atom fails: integer?()"]}
-  # """
-  # def sor(l, r) do
-  #   fn path, input ->
-  #     case l.(path, input) do
-  #       {:ok, input} ->
-  #         {:ok, input}
-
-  #       {:error, l_errors} ->
-  #         # credo:disable-for-next-line /\.Nesting/
-  #         case r.(path, input) do
-  #           {:ok, input} ->
-  #             {:ok, input}
-
-  #           {:error, r_errors} ->
-  #             {:error, l_errors ++ r_errors}
-  #         end
-  #     end
-  #   end
-  # end
-
-  # @doc ~S"""
-  # Creates a spec for keyable things such as maps
-
-  # iex> conform!(%{foo: "foo"}, keys(req: [foo: string?()]))
-  # %{foo: "foo"}
-  # iex> conform!(%{foo: "foo", bar: "bar"}, keys(req: [foo: string?()]))
-  # %{foo: "foo"}
-  # iex> conform!(%{"foo" => "foo", bar: "bar"}, keys(req: [{"foo", string?()}]))
-  # %{"foo" => "foo"}
-  # iex> conform!(%{foo: "foo"}, keys(req: [foo: string?()], opt: [bar: string?()]))
-  # %{foo: "foo"}
-  # iex> conform!(%{foo: "foo", bar: "bar"}, keys(req: [foo: string?()], opt: [bar: string?()]))
-  # %{foo: "foo", bar: "bar"}
-  # iex> conform(%{}, keys(req: [foo: string?()]))
-  # {:error, ["in: :foo val: %{} fails: :required"]}
-  # iex> conform(%{foo: 123, bar: "bar"}, keys(req: [foo: string?()]))
-  # {:error, ["in: :foo val: 123 fails: string?()"]}
-  # iex> conform(%{foo: 123, bar: 321}, keys(req: [foo: string?()], opt: [bar: string?()]))
-  # {:error, ["in: :foo val: 123 fails: string?()", "in: :bar val: 321 fails: string?()"]}
-  # iex> conform!(%{foo: "foo", bar: %{baz: "baz"}}, keys(req: [foo: string?(), bar: keys(req: [baz: lit("baz")])]))
-  # %{foo: "foo", bar: %{baz: "baz"}}
-  # iex> conform(%{foo: 123, bar: %{baz: 321}}, keys(req: [foo: string?()], opt: [bar: string?()]))
-  # iex> conform(%{foo: 123, bar: %{baz: 321}}, keys(req: [foo: string?(), bar: keys(req: [baz: lit("baz")])]))
-  # {:error, ["in: :foo val: 123 fails: string?()", "in: :bar/:baz val: 321 fails: \"baz\""]}
-  # """
-  # def keys(specs) do
-  #   reqs = Keyword.get(specs, :req, [])
-  #   opts = Keyword.get(specs, :opt, [])
-
-  #   fn path, input ->
-  #     req_keys = Enum.map(reqs, fn {key, _} -> key end)
-  #     opt_keys = Enum.map(opts, fn {key, _} -> key end)
-
-  #     req_errors =
-  #       reqs
-  #       |> Enum.map(fn {key, spec} ->
-  #         # credo:disable-for-next-line /\.Nesting/
-  #         if Map.has_key?(input, key) do
-  #           {key, spec.(path ++ [key], input[key])}
-  #         else
-  #           {key, {:error, [error(path ++ [key], input, ":required")]}}
-  #         end
-  #       end)
-  #       |> Enum.filter(fn {_, {result, _}} -> result == :error end)
-  #       |> Enum.flat_map(fn {_, {_, errors}} -> errors end)
-
-  #     opt_errors =
-  #       opts
-  #       |> Enum.map(fn {key, spec} ->
-  #         # credo:disable-for-next-line /\.Nesting/
-  #         if Map.has_key?(input, key) do
-  #           {key, spec.(path ++ [key], input[key])}
-  #         else
-  #           {key, {:ok, nil}}
-  #         end
-  #       end)
-  #       |> Enum.filter(fn {_, {result, _}} -> result == :error end)
-  #       |> Enum.flat_map(fn {_, {_, errors}} -> errors end)
-
-  #     errors = req_errors ++ opt_errors
-  #     keys = req_keys ++ opt_keys
-
-  #     if Enum.any?(errors) do
-  #       {:error, errors}
-  #     else
-  #       {:ok, Map.take(input, keys)}
-  #     end
-  #   end
-  # end
-
-  # @doc ~S"""
-  # Concatenates a sequence of predicates or patterns together. These predicates
-  # must be tagged with an atom. The conformed data is returned as a
-  # keyword list.
-
-  # iex> conform!([31, "Chris"], cat(age: integer?(), name: string?()))
-  # [age: 31, name: "Chris"]
-  # iex> conform([true, "Chris"], cat(age: integer?(), name: string?()))
-  # {:error, ["in: [0] at: :age val: true fails: integer?()"]}
-  # iex> conform([31, :chris], cat(age: integer?(), name: string?()))
-  # {:error, ["in: [1] at: :name val: :chris fails: string?()"]}
-  # iex> conform([31], cat(age: integer?(), name: string?()))
-  # {:error, ["in: [1] at: :name val: nil fails: Insufficient input"]}
-  # """
-  # def cat(opts) do
-  #   fn path, input ->
-  #     results =
-  #       opts
-  #       |> Enum.with_index
-  #       |> Enum.map(fn {{tag, spec}, i} ->
-  #         val = Enum.at(input, i)
-  #         if val do
-  #           {tag, spec.(path ++ [{:index, i}], val)}
-  #         else
-  #           {tag, {:error, [error(path ++ [{:index, i}], nil, "Insufficient input")]}}
-  #         end
-  #       end)
-
-  #     errors =
-  #       results
-  #       |> Enum.filter(fn {_, {result, _}} -> result == :error end)
-  #       |> Enum.map(fn {tag, {_, errors}} -> {tag, errors} end)
-  #       |> Enum.flat_map(fn {tag, errors} -> Enum.map(errors, &(%{&1 | at: tag})) end)
-
-  #     if Enum.any?(errors) do
-  #       {:error, errors}
-  #     else
-  #       {:ok, Enum.map(results, fn {tag, {_, data}} -> {tag, data} end)}
-  #     end
-  #   end
-  # end
-
-  # @doc ~S"""
-  # Choices between alternative predicates or patterns. The patterns must be tagged with an atom.
-  # When conforming data to this specification the data is returned as a tuple with the tag.
-
-  # iex> conform!(123, alt(num: integer?(), str: string?()))
-  # {:num, 123}
-  # iex> conform!("foo", alt(num: integer?(), str: string?()))
-  # {:str, "foo"}
-  # iex> conform(true, alt(num: integer?(), str: string?()))
-  # {:error, ["in: :num val: true fails: integer?()", "in: :str val: true fails: string?()"]}
-  # """
-  # def alt(opts) do
-  #   fn path, input ->
-  #     results =
-  #       opts
-  #       |> Enum.map(fn {tag, spec} -> {tag, spec.(path ++ [tag], input)} end)
-
-  #     good_result =
-  #       results
-  #       |> Enum.find(fn {_, {result, _}} -> result == :ok end)
-
-  #     if good_result do
-  #       {tag, {:ok, data}} = good_result
-  #       {:ok, {tag, data}}
-  #     else
-  #       errors =
-  #         results
-  #         |> Enum.flat_map(fn {_, {_, errors}} -> errors end)
-
-  #       {:error, errors}
-  #     end
-  #   end
-  # end
   defimpl Norm.Conformer.Conformable do
     def conform(%{f: f, predicate: pred}, input, path) do
       case f.(input) do

--- a/lib/norm/spec/alt.ex
+++ b/lib/norm/spec/alt.ex
@@ -4,6 +4,7 @@ defmodule Norm.Spec.Alt do
   defstruct specs: []
 
   defimpl Norm.Conformer.Conformable do
+    alias Norm.Conformer
     alias Norm.Conformer.Conformable
 
     def conform(%{specs: specs}, input, path) do
@@ -18,9 +19,7 @@ defmodule Norm.Spec.Alt do
               {:error, errors}
           end
         end)
-        |> Enum.reduce(%{ok: [], error: []}, fn {result, s}, acc ->
-          Map.put(acc, result, acc[result] ++ [s])
-        end)
+        |> Conformer.group_results
 
       if Enum.any?(result.ok) do
         {:ok, Enum.at(result.ok, 0)}

--- a/lib/norm/spec/and.ex
+++ b/lib/norm/spec/and.ex
@@ -1,7 +1,23 @@
 defmodule Norm.Spec.And do
   @moduledoc false
 
+  alias Norm.Spec
+  alias __MODULE__
+
   defstruct [:left, :right]
+
+  def new(l, r) do
+    case {l, r} do
+      {%Spec{}, %Spec{}} ->
+        %__MODULE__{left: l, right: r}
+
+      {%And{}, %Spec{}} ->
+        %__MODULE__{left: l, right: r}
+
+      _ ->
+        raise ArgumentError, "both sides of an `and` must be a predicate"
+    end
+  end
 
   defimpl Norm.Conformer.Conformable do
     alias Norm.Conformer.Conformable

--- a/lib/norm/spec/atom.ex
+++ b/lib/norm/spec/atom.ex
@@ -1,0 +1,28 @@
+defmodule Norm.Spec.Atom do
+  defstruct [:atom]
+
+  defimpl Norm.Conformer.Conformable do
+    alias Norm.Conformer
+
+    def conform(%{atom: atom}, input, path) do
+      cond do
+        not is_atom(input) ->
+          {:error, [Conformer.error(path, input, "is not an atom.")]}
+
+        atom != input ->
+          {:error, [Conformer.error(path, input, "== :#{atom}")]}
+
+        true ->
+          {:ok, atom}
+      end
+    end
+  end
+
+  if Code.ensure_loaded?(StreamData) do
+    defimpl Norm.Generatable do
+      def gen(%{atom: a}) do
+        {:ok, StreamData.constant(a)}
+      end
+    end
+  end
+end

--- a/lib/norm/spec/tuple.ex
+++ b/lib/norm/spec/tuple.ex
@@ -1,0 +1,53 @@
+defmodule Norm.Spec.Tuple do
+  defstruct args: []
+
+  defimpl Norm.Conformer.Conformable do
+    alias Norm.Conformer
+    alias Norm.Conformer.Conformable
+
+    def conform(%{args: as}, input, path) when is_tuple(input) and (length(as) != tuple_size(input)) do
+      {:error, [Conformer.error(path, input, "incorrect tuple size")]}
+    end
+
+    def conform(%{args: args}, input, path) do
+      results =
+        args
+        |> Enum.with_index()
+        |> Enum.map(fn {spec, i} -> Conformable.conform(spec, elem(input, i), path ++ [i]) end)
+        |> Conformer.group_results
+
+      if Enum.any?(results.error) do
+        {:error, results.error}
+      else
+        {:ok, List.to_tuple(results.ok)}
+      end
+    end
+  end
+
+  if Code.ensure_loaded?(StreamData) do
+    defimpl Norm.Generatable do
+      alias Norm.Generatable
+
+      def gen(%{args: as}) do
+        with list when is_list(list) <- Enum.reduce(as, [], &to_gen/2) do
+          # The list we build is in reverse order so we need to reverse first
+          generator =
+            list
+            |> Enum.reverse
+            |> List.to_tuple
+            |> StreamData.tuple()
+
+          {:ok, generator}
+        end
+      end
+
+      def to_gen(_, {:error, error}), do: {:error, error}
+      def to_gen(spec, generator) do
+        with {:ok, g} <- Generatable.gen(spec) do
+          [g | generator]
+        end
+      end
+    end
+  end
+end
+

--- a/test/norm/spec_test.exs
+++ b/test/norm/spec_test.exs
@@ -20,6 +20,52 @@ defmodule Norm.SpecTest do
       assert errors == ["val: 20 fails: &(&1 >= 21)"]
     end
 
+    test "and can only be used to compose predicates or other ands" do
+      assert_raise ArgumentError, fn ->
+        spec(is_integer() and :ok)
+      end
+
+      assert_raise ArgumentError, fn ->
+        spec({spec(is_binary()), spec(is_integer())} and :ok)
+      end
+
+      assert_raise ArgumentError, fn ->
+        spec({spec(is_binary()), spec(is_integer())} and &(&1 > 0))
+      end
+
+      assert_raise ArgumentError, fn ->
+        spec(:ok and is_atom())
+      end
+    end
+
+    test "or can compose with atoms or tuples" do
+      s = spec(:ok or :error or (is_binary() and fn x -> x == "error" end))
+
+      assert :ok == conform!(:ok, s)
+      assert :error == conform!(:error, s)
+      assert "error" == conform!("error", s)
+      assert {:error, errors} = conform("foo", s)
+      assert errors == [
+        "val: \"foo\" fails: is not an atom.",
+        "val: \"foo\" fails: is not an atom.",
+        "val: \"foo\" fails: fn x -> x == \"error\" end"
+      ]
+
+      check all g <- gen(spec(:ok or :error or is_binary())) do
+        assert g == :ok || g == :error || is_binary(g)
+      end
+
+      maybe = spec({spec(:ok), spec(is_binary())} or {spec(:error), spec(is_integer())})
+      assert {:ok, "chris"} == conform!({:ok, "chris"}, maybe)
+
+      check all m <- gen(maybe) do
+        case m do
+          {:ok, b} -> assert is_binary(b)
+          {:error, i} -> assert is_integer(i)
+        end
+      end
+    end
+
     test "'and' and 'or' can be chained" do
       s = spec(is_integer() and fn x -> x >= 21 end and fn x -> x < 30 end)
 
@@ -42,6 +88,56 @@ defmodule Norm.SpecTest do
       foo = spec(Foo.match?("foo"))
       assert "foo" == conform!("foo", foo)
       assert {:error, ["val: \"bar\" fails: Foo.match?(\"foo\")"]} == conform("bar", foo)
+    end
+
+    @tag :skip
+    test "and and or returned conformed values" do
+      flunk "Not implemented"
+    end
+
+    test "can match atoms" do
+      assert :ok == conform!(:ok, spec(:ok))
+      assert {:error, errors} = conform("foo", spec(:ok))
+      assert errors == ["val: \"foo\" fails: is not an atom."]
+      assert {:error, errors} = conform(:mismatch, spec(:ok))
+      assert errors == ["val: :mismatch fails: == :ok"]
+    end
+
+    test "can match patterns of tuples" do
+      ok = spec({spec(:ok), spec(is_integer())})
+      error = spec({spec(:error), spec(is_binary())})
+      three = spec({spec(is_integer()), spec(is_integer()), spec(is_integer())})
+
+      assert {:ok, 123}
+      |> conform!(ok) == {:ok, 123}
+
+      assert {:error, "something's wrong"}
+      |> conform!(error) == {:error, "something's wrong"}
+
+      assert {1, 2, 3} == conform!({1, 2, 3}, three)
+      assert {:error, errors} = conform({1, :bar, "foo"}, three)
+      assert errors == [
+        "val: :bar fails: is_integer() in: 1",
+        "val: \"foo\" fails: is_integer() in: 2"
+      ]
+
+      assert {:error, errors} = conform({:ok, "foo"}, ok)
+      assert errors == ["val: \"foo\" fails: is_integer() in: 1"]
+
+      assert {:error, errors} = conform({:ok, "foo", 123}, ok)
+      assert errors == ["val: {:ok, \"foo\", 123} fails: incorrect tuple size"]
+
+      assert {:error, errors} = conform({:ok, 123, "foo"}, ok)
+      assert errors == ["val: {:ok, 123, \"foo\"} fails: incorrect tuple size"]
+    end
+
+    test "tuples can be composed with schema's and selections" do
+      user = schema(%{name: spec(is_binary()), age: spec(is_integer())})
+      ok = spec({spec(:ok), selection(user, [:name])})
+
+      assert {:ok, %{name: "chris"}} == conform!({:ok, %{name: "chris", age: 31}}, ok)
+      assert {:error, errors} = conform({:ok, %{age: 31}}, ok)
+      assert errors == ["val: %{age: 31} fails: :required in: 1/:name"]
     end
   end
 
@@ -78,6 +174,8 @@ defmodule Norm.SpecTest do
         assert is_integer(i)
         assert i > 0
       end
+
+      assert gen(spec(is_integer() and fn i -> i > 0 end and &(&1 > 60)))
     end
 
     test "works with 'or'" do
@@ -90,6 +188,40 @@ defmodule Norm.SpecTest do
     test "'or' returns an error if it can't infer both generators" do
       assert_raise Norm.GeneratorError, fn ->
         Enum.take(gen(spec(is_integer() or &(&1 > 0))), 1)
+      end
+    end
+
+    property "works with atoms" do
+      check all foo <- gen(spec(:foo)) do
+        assert is_atom(foo)
+        assert foo == :foo
+      end
+
+      check all a <- gen(spec(is_atom())) do
+        assert is_atom(a)
+      end
+    end
+
+    property "works with tuples" do
+      ok = spec({spec(:ok), schema(%{name: spec(is_binary())})})
+
+      check all tuple <- gen(ok) do
+        assert {:ok, user} = tuple
+        assert Map.keys(user) == [:name]
+        assert is_binary(user.name)
+      end
+
+      assert_raise Norm.GeneratorError, fn ->
+        gen(spec({spec(&(&1 > 0)), spec(is_binary())}))
+      end
+
+      ints = spec({spec(is_integer()), spec(is_integer()), spec(is_integer())})
+
+      check all is <- gen(ints) do
+        assert {a, b, c} = is
+        assert is_integer(a)
+        assert is_integer(b)
+        assert is_integer(c)
       end
     end
 


### PR DESCRIPTION
This PR introduces the ability to match on the shapes of tuples and on bare atoms. In order to not break existing functionality, I needed to update the way that `and` is matched and created so that ensures only predicates can be "and-ed"` together. `or` can compose arbitrarily though.