### PR TITLE
primitive type generators (is_float test)

### DIFF
--- a/lib/norm/spec.ex
+++ b/lib/norm/spec.ex
@@ -81,6 +81,9 @@ defmodule Norm.Spec do
           :is_integer ->
             {:ok, StreamData.integer()}
 
+          :is_float ->
+            {:ok, StreamData.float()}
+
           :is_binary ->
             {:ok, StreamData.binary()}
 

--- a/test/norm/generators/primitives_test.exs
+++ b/test/norm/generators/primitives_test.exs
@@ -1,0 +1,14 @@
+defmodule Norm.Generators.GeneratorTest do
+  use ExUnit.Case, async: true
+  import Norm
+
+  alias Norm.Generator
+
+  describe "generates primitive types" do
+    test "generates values from spec(is_float())" do
+      [output | _] = is_float() |> spec() |> gen() |> Enum.take(1)
+
+      assert is_float(output)
+    end
+  end
+end


### PR DESCRIPTION
Hi Chris! I really enjoyed your talk at ElixirConf. Inter-service contracts are something I feel like get implemented from scratch in so many api style code bases (and ultimately is solved by throwing hours at bugs or custom casting/validation/whatever modules).

I'll definitely be trying out Norm and look forward to checking out some of the resources you provided in the talk!

I guess I mostly wanted to open this PR to see how I could contribute (rather than an issue). I noticed one of your asks for early contributions was supporting generators for other primitive types. I'd love to help there! Curious if a PR adding some of them in would be helpful.

I haven't really contributed to open source or libraries, so I thought I'd put up a WIP where I added support for ```gen(spec(is_float()))```. I'm not sure if this is what you had in mind for that task / TODO.

If you had something else in mind, I'd love to get feedback and still try and help contribute! If this is OK, I'll start including other primitives!

P.s. sorry for the spacing in the files, I think that was my auto-formatter. LMK if you'd also like me to remove the noise or if its OK