### PR TITLE
Add inspect implementation

### DIFF
--- a/lib/norm/spec.ex
+++ b/lib/norm/spec.ex
@@ -129,4 +129,15 @@ defmodule Norm.Spec do
       %{path: path, input: input, msg: msg, at: nil}
     end
   end
+
+  @doc false
+  def __inspect__(spec) do
+    spec.predicate
+  end
+
+  defimpl Inspect do
+    def inspect(spec, _) do
+      Inspect.Algebra.concat(["#Norm.Spec<", spec.predicate, ">"])
+    end
+  end
 end

--- a/lib/norm/spec/and.ex
+++ b/lib/norm/spec/and.ex
@@ -48,4 +48,17 @@ defmodule Norm.Spec.And do
       end
     end
   end
+
+  @doc false
+  def __inspect__(%{left: left, right: right}) do
+    left = left.__struct__.__inspect__(left)
+    right = right.__struct__.__inspect__(right)
+    Inspect.Algebra.concat([left, " and ", right])
+  end
+
+  defimpl Inspect do
+    def inspect(struct, _) do
+      Inspect.Algebra.concat(["#Norm.Spec<", @for.__inspect__(struct), ">"])
+    end
+  end
 end

--- a/lib/norm/spec/or.ex
+++ b/lib/norm/spec/or.ex
@@ -35,4 +35,17 @@ defmodule Norm.Spec.Or do
       end
     end
   end
+
+  @doc false
+  def __inspect__(%{left: left, right: right}) do
+    left = left.__struct__.__inspect__(left)
+    right = right.__struct__.__inspect__(right)
+    Inspect.Algebra.concat([left, " or ", right])
+  end
+
+  defimpl Inspect do
+    def inspect(struct, _) do
+      Inspect.Algebra.concat(["#Norm.Spec<", @for.__inspect__(struct), ">"])
+    end
+  end
 end

--- a/test/norm/spec_test.exs
+++ b/test/norm/spec_test.exs
@@ -108,4 +108,24 @@ defmodule Norm.SpecTest do
       end
     end
   end
+
+  describe "inspect" do
+    test "predicate" do
+      assert inspect(spec(is_integer())) == "#Norm.Spec<is_integer()>"
+    end
+
+    test "lambda" do
+      assert inspect(spec(&(&1 >= 21))) == "#Norm.Spec<&(&1 >= 21)>"
+    end
+
+    test "and" do
+      assert inspect(spec(is_integer() and (&(&1 >= 21)))) ==
+               "#Norm.Spec<is_integer() and &(&1 >= 21)>"
+    end
+
+    test "or" do
+      assert inspect(spec(is_integer() or is_float())) ==
+               "#Norm.Spec<is_integer() or is_float()>"
+    end
+  end
 end


### PR DESCRIPTION
This allows pretty printing that is not used in Norm itself, but is
useful for tools built on top.