### PR TITLE
Short-circuit 'and'

### DIFF
--- a/lib/norm/spec/and.ex
+++ b/lib/norm/spec/and.ex
@@ -23,16 +23,8 @@ defmodule Norm.Spec.And do
     alias Norm.Conformer.Conformable
 
     def conform(%{left: l, right: r}, input, path) do
-      errors =
-        [l, r]
-        |> Enum.map(fn spec -> Conformable.conform(spec, input, path) end)
-        |> Enum.filter(fn {result, _} -> result == :error end)
-        |> Enum.flat_map(fn {_, msg} -> msg end)
-
-      if Enum.any?(errors) do
-        {:error, errors}
-      else
-        {:ok, input}
+      with {:ok, _} <- Conformable.conform(l, input, path) do
+        Conformable.conform(r, input, path)
       end
     end
   end

--- a/test/norm/spec_test.exs
+++ b/test/norm/spec_test.exs
@@ -11,13 +11,13 @@ defmodule Norm.SpecTest do
 
   describe "spec/1" do
     test "can compose specs with 'and'" do
-      can_drink = spec(is_integer() and (&(&1 >= 21)))
+      hex = spec(is_binary() and (&String.starts_with?(&1, "#")))
 
-      assert 21 == conform!(21, can_drink)
-      assert {:error, errors} = conform("21", can_drink)
-      assert errors == ["val: \"21\" fails: is_integer()"]
-      assert {:error, errors} = conform(20, can_drink)
-      assert errors == ["val: 20 fails: &(&1 >= 21)"]
+      assert "#000000" == conform!("#000000", hex)
+      assert {:error, errors} = conform(nil, hex)
+      assert errors == ["val: nil fails: is_binary()"]
+      assert {:error, errors} = conform("bad", hex)
+      assert errors == ["val: \"bad\" fails: &(String.starts_with?(&1, \"#\"))"]
     end
 
     test "'and' and 'or' can be chained" do


### PR DESCRIPTION
Before this patch both left and right were _always_ conformed which caused this to fail:

    iex> hex = spec(is_binary() and (&String.starts_with?(&1, "#")))
    iex> conform!(nil, hex)
    ** (FunctionClauseError) no function clause matching in String.starts_with?/2

    The following arguments were given to String.starts_with?/2:

        # 1
        nil

        # 2
        "#"