### PR TITLE
Fix issue where is_nil() spec would not match in Union

### DIFF
--- a/lib/norm/spec/union.ex
+++ b/lib/norm/spec/union.ex
@@ -18,7 +18,7 @@ defmodule Norm.Spec.Union do
         |> Enum.map(fn spec -> Conformable.conform(spec, input, path) end)
         |> Conformer.group_results()
 
-      if Enum.any?(result.ok) do
+      if result.ok != [] do
         {:ok, Enum.at(result.ok, 0)}
       else
         {:error, List.flatten(result.error)}

--- a/test/norm/union_test.exs
+++ b/test/norm/union_test.exs
@@ -16,6 +16,19 @@ defmodule Norm.UnionTest do
                "val: 123 fails: is_binary()"
              ]
     end
+
+    test "accepts nil if part of the union" do
+      union = one_of([nil, spec(is_binary())])
+
+      assert nil == conform!(nil, union)
+      assert "foo" == conform!("foo", union)
+      assert {:error, errors} = conform(42, union)
+
+      assert errors == [
+               "val: 42 fails: is_nil()",
+               "val: 42 fails: is_binary()"
+             ]
+    end
   end
 
   describe "generation" do

--- a/test/norm/union_test.exs
+++ b/test/norm/union_test.exs
@@ -18,7 +18,7 @@ defmodule Norm.UnionTest do
     end
 
     test "accepts nil if part of the union" do
-      union = one_of([nil, spec(is_binary())])
+      union = one_of([spec(is_nil()), spec(is_binary())])
 
       assert nil == conform!(nil, union)
       assert "foo" == conform!("foo", union)


### PR DESCRIPTION
Hi and thanks for having written and maintaining Norm.

While experimenting with it, I noticed that `spec(is_nil())` is never considered to match when used as part of a union (`one_of`).  (See the added test case which would produce "val: nil fails: is_binary()" even though nil is listed as an allowed value)

The reasons is that `Enum.any?` was being used to check if any of the specs matched. Unfortunately, what `Enum.any?` actually does is that it uses the identity function on all the elements of the list and, obviously,`nil` is not truthy (see https://hexdocs.pm/elixir/Enum.html#any?/2).

I fixed it by replacing the `Enum.any?` call with a coparison against the empty list wich works for my problem and did not break any of the other tests.
Please tell me if you think there is a good reasony why falsy `ok` entries must be ignored or if there are any other things I should improve.
