### PR TITLE
Return a list of errors from conform/2

### DIFF
--- a/lib/norm/conformer.ex
+++ b/lib/norm/conformer.ex
@@ -4,11 +4,7 @@ defmodule Norm.Conformer do
   # conformable types
 
   def conform(spec, input) do
-    # If we get errors then we should convert them to messages. Otherwise
-    # we just let good results fall through.
-    with {:error, errors} <- Norm.Conformer.Conformable.conform(spec, input, []) do
-      {:error, Enum.map(errors, &error_to_msg/1)}
-    end
+    Norm.Conformer.Conformable.conform(spec, input, [])
   end
 
   def group_results(results) do
@@ -21,10 +17,10 @@ defmodule Norm.Conformer do
   end
 
   def error(path, input, msg) do
-    %{path: path, input: input, msg: msg, at: nil}
+    %{path: path, input: input, spec: msg}
   end
 
-  def error_to_msg(%{path: path, input: input, msg: msg}) do
+  def error_to_msg(%{path: path, input: input, spec: msg}) do
     path = if path == [], do: nil, else: "in: " <> build_path(path)
     val = "val: #{format_val(input)}"
     fails = "fails: #{msg}"

--- a/lib/norm/errors.ex
+++ b/lib/norm/errors.ex
@@ -2,7 +2,10 @@ defmodule Norm.MismatchError do
   defexception [:message]
 
   def exception(errors) do
-    msg = Enum.join(errors, "\n")
+    msg =
+      errors
+      |> Enum.map(&Norm.Conformer.error_to_msg/1)
+      |> Enum.join("\n")
 
     %__MODULE__{message: "Could not conform input:\n" <> msg}
   end

--- a/lib/norm/schema.ex
+++ b/lib/norm/schema.ex
@@ -34,10 +34,11 @@ defmodule Norm.Schema do
   end
 
   defimpl Norm.Conformer.Conformable do
+    alias Norm.Conformer
     alias Norm.Conformer.Conformable
 
     def conform(_, input, path) when not is_map(input) do
-      {:error, [error(path, input, "not a map")]}
+      {:error, [Conformer.error(path, input, "not a map")]}
     end
 
     def conform(%{specs: specs, struct: target}, input, path) when not is_nil(target) do
@@ -52,7 +53,7 @@ defmodule Norm.Schema do
           |> Atom.to_string()
           |> String.replace("Elixir.", "")
 
-        {:error, [error(path, input, "#{short_name}")]}
+        {:error, [Conformer.error(path, input, "#{short_name}")]}
       end
     end
 
@@ -82,7 +83,7 @@ defmodule Norm.Schema do
     defp check_spec({key, nil}, input, path) do
       case Map.has_key?(input, key) do
         false ->
-          {key, {:error, [error(path ++ [key], input, ":required")]}}
+          {key, {:error, [Conformer.error(path ++ [key], input, ":required")]}}
 
         true ->
           {key, {:ok, Map.get(input, key)}}
@@ -92,16 +93,12 @@ defmodule Norm.Schema do
     defp check_spec({key, spec}, input, path) do
       case Map.has_key?(input, key) do
         false ->
-          {key, {:error, [error(path ++ [key], input, ":required")]}}
+          {key, {:error, [Conformer.error(path ++ [key], input, ":required")]}}
 
         true ->
           val = Map.get(input, key)
           {key, Conformable.conform(spec, val, path ++ [key])}
       end
-    end
-
-    defp error(path, input, msg) do
-      %{path: path, input: input, msg: msg, at: nil}
     end
   end
 

--- a/lib/norm/spec.ex
+++ b/lib/norm/spec.ex
@@ -118,15 +118,11 @@ defmodule Norm.Spec do
           {:ok, input}
 
         false ->
-          {:error, [error(path, input, pred)]}
+          {:error, [Norm.Conformer.error(path, input, pred)]}
 
         _ ->
           raise ArgumentError, "Predicates must return a boolean value"
       end
-    end
-
-    def error(path, input, msg) do
-      %{path: path, input: input, msg: msg, at: nil}
     end
   end
 

--- a/lib/norm/spec/selection.ex
+++ b/lib/norm/spec/selection.ex
@@ -66,6 +66,7 @@ defmodule Norm.Spec.Selection do
   end
 
   defimpl Norm.Conformer.Conformable do
+    alias Norm.Conformer
     alias Norm.Conformer.Conformable
 
     def conform(%{subset: subset}, input, path) do
@@ -77,7 +78,7 @@ defmodule Norm.Spec.Selection do
           if val do
             {key, Conformable.conform(spec, val, path ++ [key])}
           else
-            {key, {:error, [error(path ++ [key], input, ":required")]}}
+            {key, {:error, [Conformer.error(path ++ [key], input, ":required")]}}
           end
         end)
         |> Enum.reduce(%{ok: [], error: []}, fn {key, {result, r}}, acc ->
@@ -93,10 +94,6 @@ defmodule Norm.Spec.Selection do
       else
         {:ok, Enum.into(results.ok, %{})}
       end
-    end
-
-    defp error(path, input, msg) do
-      %{path: path, input: input, msg: msg, at: nil}
     end
   end
 end

--- a/test/norm/generator_test.exs
+++ b/test/norm/generator_test.exs
@@ -9,7 +9,7 @@ defmodule Norm.GeneratorTest do
       spec = Generator.new(spec(is_integer()), :null)
 
       assert 123 == conform!(123, spec)
-      assert {:error, ["val: \"foo\" fails: is_integer()"]} = conform("foo", spec)
+      assert {:error, [%{spec: "is_integer()", input: "foo", path: []}]} = conform("foo", spec)
     end
 
     test "raises when generating" do

--- a/test/norm/selection_test.exs
+++ b/test/norm/selection_test.exs
@@ -24,7 +24,7 @@ defmodule Norm.SelectionTest do
                conform!(@input, selection(user_schema(), [:age, :name]))
 
       assert {:error, errors} = conform(%{age: -100}, selection(user_schema(), [:age]))
-      assert errors == ["val: -100 in: :age fails: &(&1 > 0)"]
+      assert errors == [%{spec: "&(&1 > 0)", input: -100, path: [:age]}]
     end
 
     test "works with nested schemas" do
@@ -33,11 +33,11 @@ defmodule Norm.SelectionTest do
 
       assert %{user: %{age: 31}} == conform!(%{user: %{age: 31}}, selection)
       assert {:error, errors} = conform(%{user: %{age: -100}}, selection)
-      assert errors == ["val: -100 in: :user/:age fails: &(&1 > 0)"]
+      assert errors == [%{spec: "&(&1 > 0)", input: -100, path: [:user, :age]}]
       assert {:error, errors} = conform(%{user: %{name: "chris"}}, selection)
-      assert errors == ["val: %{name: \"chris\"} in: :user/:age fails: :required"]
+      assert errors == [%{spec: ":required", input: %{name: "chris"}, path: [:user, :age]}]
       assert {:error, errors} = conform(%{fauxuser: %{age: 31}}, selection)
-      assert errors == ["val: %{fauxuser: %{age: 31}} in: :user fails: :required"]
+      assert errors == [%{spec: ":required", input: %{fauxuser: %{age: 31}}, path: [:user]}]
     end
 
     test "errors if there are keys that aren't specified in a schema" do

--- a/test/norm/spec_test.exs
+++ b/test/norm/spec_test.exs
@@ -15,9 +15,9 @@ defmodule Norm.SpecTest do
 
       assert "#000000" == conform!("#000000", hex)
       assert {:error, errors} = conform(nil, hex)
-      assert errors == ["val: nil fails: is_binary()"]
+      assert errors == [%{spec: "is_binary()", input: nil, path: []}]
       assert {:error, errors} = conform("bad", hex)
-      assert errors == ["val: \"bad\" fails: &(String.starts_with?(&1, \"#\"))"]
+      assert errors == [%{spec: "&(String.starts_with?(&1, \"#\"))", input: "bad", path: []}]
     end
 
     test "'and' and 'or' can be chained" do
@@ -33,15 +33,15 @@ defmodule Norm.SpecTest do
 
       evens = spec(is_integer() and Integer.is_even())
       assert 2 == conform!(2, evens)
-      assert {:error, ["val: 3 fails: Integer.is_even()"]} == conform(3, evens)
+      assert {:error, [%{spec: "Integer.is_even()", input: 3, path: []}]} == conform(3, evens)
 
       hello = spec(Foo.hello?())
       assert "hello" == conform!("hello", hello)
-      assert {:error, ["val: \"foo\" fails: Foo.hello?()"]} == conform("foo", hello)
+      assert {:error, [%{spec: "Foo.hello?()", input: "foo", path: []}]} == conform("foo", hello)
 
       foo = spec(Foo.match?("foo"))
       assert "foo" == conform!("foo", foo)
-      assert {:error, ["val: \"bar\" fails: Foo.match?(\"foo\")"]} == conform("bar", foo)
+      assert {:error, [%{spec: "Foo.match?(\"foo\")", input: "bar", path: []}]} == conform("bar", foo)
     end
   end
 

--- a/test/norm/union_test.exs
+++ b/test/norm/union_test.exs
@@ -12,9 +12,9 @@ defmodule Norm.UnionTest do
       assert {:error, errors} = conform(123, union)
 
       assert errors == [
-               "val: 123 fails: is not an atom.",
-               "val: 123 fails: is_binary()"
-             ]
+        %{spec: "is not an atom.", input: 123, path: []},
+        %{spec: "is_binary()", input: 123, path: []}
+      ]
     end
 
     test "accepts nil if part of the union" do
@@ -25,9 +25,9 @@ defmodule Norm.UnionTest do
       assert {:error, errors} = conform(42, union)
 
       assert errors == [
-               "val: 42 fails: is_nil()",
-               "val: 42 fails: is_binary()"
-             ]
+        %{spec: "is_nil()", input: 42, path: []},
+        %{spec: "is_binary()", input: 42, path: []}
+      ]
     end
   end
 


### PR DESCRIPTION
After this PR `conform/2` will no longer return a list of strings and will return a list of errors. This should help clients and other libraries craft error messages that make the most sense for their use case.