### PR TITLE
Better enumerable type check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 norm-*.tar
 
+# Elixir Language Server (e.g. for VS Code users).
+/.elixir_ls

--- a/test/norm_test.exs
+++ b/test/norm_test.exs
@@ -161,6 +161,24 @@ defmodule NormTest do
       assert %{1 => :foo, 2 => :bar} == conform!(%{1 => :foo, 2 => :bar}, spec)
     end
 
+    test "doesn't throw for non-enumerable inputs" do
+      spec = map_of(spec(is_integer()), spec(is_atom()))
+
+      assert {:error, errors} = conform("not-a-map!", spec)
+      assert errors == [
+        %{spec: "not enumerable", input: "not-a-map!", path: []}
+      ]
+    end
+
+    test "doesn't throw for list inputs" do
+      spec = map_of(spec(is_integer()), spec(is_atom()))
+
+      assert {:error, errors} = conform([1, 2, 3], spec)
+      assert errors == [
+        %{spec: "not a map", input: [1, 2, 3], path: []}
+      ]
+    end
+
     property "can be generated" do
       check all m <- gen(map_of(spec(is_integer()), spec(is_atom()))) do
         assert is_map(m)
@@ -178,6 +196,15 @@ defmodule NormTest do
       assert errors == [
         %{spec: "is_atom()", input: 1, path: [1]},
         %{spec: "is_atom()", input: "test", path: [2]}
+      ]
+    end
+
+    test "doesn't throw for non-enumerable inputs" do
+      spec = coll_of(spec(is_integer()))
+
+      assert {:error, errors} = conform("not-a-collection!", spec)
+      assert errors == [
+        %{spec: "not enumerable", input: "not-a-collection!", path: []}
       ]
     end
 


### PR DESCRIPTION
My colleague @mpneuried noticed that `map_of` throws an exception when matched against non-enumerable values (e.g. `conform("foo", map_of(spec(is_interger()), spec(is_binary()))` would throw `** (Protocol.UndefinedError) protocol Enumerable not implemented for "foo" of type BitString...`).

In this pull request, we fix this issue by executing additional checks in collection.ex. The first one is to ensure that the given input value is actually enumerable. If not, conform now fails with `not enumerable`.

Then we noticed that passing a simple list into the `conform` from above would also throw an exception, because the code assumes that the list contains key-value-tuples, so we introduced another check. If the user wrote `map_of` but then passed a simple list (or any other enumerable structure that is not represented as a list of two element tuples), the `not a map` error is returned.