### PR TITLE
Optionality in schemas

### DIFF
--- a/lib/norm.ex
+++ b/lib/norm.ex
@@ -512,7 +512,8 @@ defmodule Norm do
   in the selection are still considered optional. Selections, like schemas,
   are open and allow unspecied keys to be passed through. If no selectors are
   provided then `selection` defaults to `:all` and recursively marks all keys in
-  all schema's as required.
+  all nested schema's. If the schema includes internal selections these selections
+  will not be overwritten.
 
   ## Examples
 

--- a/lib/norm.ex
+++ b/lib/norm.ex
@@ -478,17 +478,61 @@ defmodule Norm do
   end
 
   @doc ~S"""
-  Creates a re-usable schema.
+  Creates a re-usable schema. Schema's are open which means that all keys are
+  optional and any non-specified keys are passed through without being conformed.
+  If you need to mark keys as required instead of optional you can use `selection`.
 
   ## Examples
 
-      iex> conform!(%{age: 31, name: "chris"},
-      ...>   schema(%{age: spec(is_integer()), name: spec(is_binary())})
-      ...> )
+      iex> valid?(%{}, schema(%{name: spec(is_binary())}))
+      true
+      iex> valid?(%{name: "Chris"}, schema(%{name: spec(is_binary())}))
+      true
+      iex> valid?(%{name: "Chris", age: 31}, schema(%{name: spec(is_binary())}))
+      true
+      iex> valid?(%{age: 31}, schema(%{name: spec(is_binary())}))
+      true
+      iex> valid?(%{name: 123}, schema(%{name: spec(is_binary())}))
+      false
+      iex> conform!(%{}, schema(%{name: spec(is_binary())}))
+      %{}
+      iex> conform!(%{age: 31, name: "chris"}, schema(%{name: spec(is_binary())}))
       %{age: 31, name: "chris"}
+      iex> conform!(%{age: 31}, schema(%{name: spec(is_binary())}))
+      %{age: 31}
+      iex> conform!(%{user: %{name: "chris"}}, schema(%{user: schema(%{name: spec(is_binary())})}))
+      %{user: %{name: "chris"}}
   """
   def schema(input) when is_map(input) do
     Schema.build(input)
+  end
+
+  @doc ~S"""
+  Selections can be used to mark keys on a schema as required. Any unspecified keys
+  in the selection are still considered optional. Selections, like schemas,
+  are open and allow unspecied keys to be passed through. If no selectors are
+  provided then `selection` defaults to `:all` and recursively marks all keys in
+  all schema's as required.
+
+  ## Examples
+
+      iex> valid?(%{name: "chris"}, selection(schema(%{name: spec(is_binary())}), [:name]))
+      true
+      iex> valid?(%{}, selection(schema(%{name: spec(is_binary())}), [:name]))
+      false
+      iex> valid?(%{user: %{name: "chris"}}, selection(schema(%{user: schema(%{name: spec(is_binary())})}), [user: [:name]]))
+      true
+      iex> conform!(%{name: "chris"}, selection(schema(%{name: spec(is_binary())}), [:name]))
+      %{name: "chris"}
+      iex> conform!(%{name: "chris", age: 31}, selection(schema(%{name: spec(is_binary())}), [:name]))
+      %{name: "chris", age: 31}
+
+  ## Require all keys
+      iex> valid?(%{user: %{name: "chris"}}, selection(schema(%{user: schema(%{name: spec(is_binary())})})))
+      true
+  """
+  def selection(%Schema{} = schema, path \\ :all) do
+    Selection.new(schema, path)
   end
 
   @doc ~S"""
@@ -525,19 +569,6 @@ defmodule Norm do
   """
   def one_of(specs) when is_list(specs) do
     Union.new(specs)
-  end
-
-  @doc ~S"""
-  Selections provide a way to allow optional keys in a schema. This allows
-  schema's to be defined once and re-used in multiple scenarios.
-
-  ## Examples
-
-      iex> conform!(%{age: 31}, selection(schema(%{age: spec(is_integer()), name: spec(is_binary())}), [:age]))
-      %{age: 31}
-  """
-  def selection(%Schema{} = schema, path) do
-    Selection.new(schema, path)
   end
 
   @doc ~S"""

--- a/test/norm/selection_test.exs
+++ b/test/norm/selection_test.exs
@@ -2,13 +2,11 @@ defmodule Norm.SelectionTest do
   use ExUnit.Case, async: true
   import Norm
 
-  def user_schema,
-    do:
-      schema(%{
-        name: spec(is_binary()),
-        age: spec(is_integer() and (&(&1 > 0))),
-        email: spec(is_binary() and (&(&1 =~ ~r/@/)))
-      })
+  def user_schema, do: schema(%{
+    name: spec(is_binary()),
+    age: spec(is_integer() and (&(&1 > 0))),
+    email: spec(is_binary() and (&(&1 =~ ~r/@/)))
+  })
 
   @input %{
     name: "chris",
@@ -18,11 +16,10 @@ defmodule Norm.SelectionTest do
 
   describe "selection/2" do
     test "can define selections of schemas" do
-      assert %{age: 31} == conform!(@input, selection(user_schema(), [:age]))
-
-      assert %{age: 31, name: "chris"} ==
-               conform!(@input, selection(user_schema(), [:age, :name]))
-
+      assert @input == conform!(@input, selection(user_schema(), [:age]))
+      assert @input == conform!(@input, selection(user_schema(), [:age, :name]))
+      assert @input == conform!(@input, selection(user_schema(), [:age, :name, :email]))
+      assert @input == conform!(@input, selection(schema(%{name: spec(is_binary())}), [:name]))
       assert {:error, errors} = conform(%{age: -100}, selection(user_schema(), [:age]))
       assert errors == [%{spec: "&(&1 > 0)", input: -100, path: [:age]}]
     end
@@ -40,6 +37,13 @@ defmodule Norm.SelectionTest do
       assert errors == [%{spec: ":required", input: %{fauxuser: %{age: 31}}, path: [:user]}]
     end
 
+    test "if no keys are selected all keys are enforced recursively" do
+      assert valid?(@input, selection(user_schema()))
+      refute valid?(%{}, selection(user_schema()))
+      refute valid?(%{name: "chris"}, selection(user_schema()))
+      refute valid?(%{name: "chris", age: 31}, selection(user_schema()))
+    end
+
     test "errors if there are keys that aren't specified in a schema" do
       assert_raise Norm.SpecError, fn ->
         selection(schema(%{age: spec(is_integer())}), [:name])
@@ -52,14 +56,6 @@ defmodule Norm.SelectionTest do
       assert_raise Norm.SpecError, fn ->
         selection(schema(%{user: schema(%{age: spec(is_integer())})}), foo: [:name])
       end
-    end
-
-    test "allows schemas to grow" do
-      schema = schema(%{user: schema(%{name: spec(is_binary())})})
-      select = selection(schema, user: [:name])
-
-      assert %{user: %{name: "chris"}} ==
-               conform!(%{user: %{name: "chris", age: 31}, foo: :foo}, select)
     end
   end
 
@@ -108,14 +104,12 @@ defmodule Norm.SelectionTest do
     end
 
     test "can generate inner schemas" do
-      s =
-        schema(%{
-          user:
-            schema(%{
-              name: spec(is_binary()),
-              age: spec(is_integer())
-            })
+      s = schema(%{
+        user: schema(%{
+          name: spec(is_binary()),
+          age: spec(is_integer())
         })
+      })
 
       select = selection(s, user: [:age])
 

--- a/test/norm_test.exs
+++ b/test/norm_test.exs
@@ -48,7 +48,7 @@ defmodule NormTest do
       user = schema(%{name: spec(is_binary()), age: spec(is_integer())})
       ok = {:ok, selection(user, [:name])}
 
-      assert {:ok, %{name: "chris"}} == conform!({:ok, %{name: "chris", age: 31}}, ok)
+      assert {:ok, %{name: "chris", age: 31}} == conform!({:ok, %{name: "chris", age: 31}}, ok)
       assert {:error, errors} = conform({:ok, %{age: 31}}, ok)
       assert errors == [%{spec: ":required", input: %{age: 31}, path: [1, :name]}]
     end
@@ -102,18 +102,6 @@ defmodule NormTest do
 
       spec = with_gen(schema(%{foo: spec(is_integer())}), StreamData.constant("foo"))
       for str <- Enum.take(gen(spec), 5), do: assert(str == "foo")
-    end
-  end
-
-  describe "schema/1" do
-    test "creates a re-usable schema" do
-      s = schema(%{name: spec(is_binary())})
-      assert %{name: "Chris"} == conform!(%{name: "Chris"}, s)
-      assert {:error, _errors} = conform(%{foo: "bar"}, s)
-      assert {:error, _errors} = conform(%{name: 123}, s)
-
-      user = schema(%{user: schema(%{name: spec(is_binary())})})
-      assert %{user: %{name: "Chris"}} == conform!(%{user: %{name: "Chris"}}, user)
     end
   end
 
@@ -215,15 +203,18 @@ defmodule NormTest do
         %{name: "andra", age: 30}
       ]
 
-      assert [%{name: "chris"}, %{name: "andra"}] == conform!(input, spec)
+      assert conform!(input, spec) == [
+        %{name: "chris", age: 31, email: "c@keathley.io"},
+        %{name: "andra", age: 30}
+      ]
 
       input = [
-        %{age: 31, email: "c@keathley.io"},
+        %{age: 31, email: "c@keathley.io", name: nil},
         %{name: :andra, age: 30},
       ]
       assert {:error, errors} = conform(input, spec)
       assert errors == [
-        %{spec: ":required", input: %{age: 31, email: "c@keathley.io"}, path: [0, :name]},
+        %{spec: "is_binary()", input: nil, path: [0, :name]},
         %{spec: "is_binary()", input: :andra, path: [1, :name]}
       ]
     end


### PR DESCRIPTION
This PR introduces a fairly substantial change to the semantics of schema's and selections. I'll try to describe the behavior before and after these changes as well as my rationale.

## The current state

Currently, schemas disregard any non-specified keys in the input map and return only what's been specified. Selections further filter this input set in order to return a limited set of keys. This code should demonstrate the idea:

```elixir
user = schema(%{name: spec(is_binary())})
%{name: "chris"} = conform!(%{name: "chris", age: 31}, user)
```

Furthermore, all of the schema's keys are required in the input map.

## The problems

By removing unspecified keys from the input we make it impossible to support dynamic user input or arbitrary middlewares. This example should demonstrate what I mean:

```elixir
def env_s, do: schema(%{content_type: spec(is_binary()), method: spec(& &1 in ["POST", "GET"]})

def user_middleware(env) do
  # The env should contain the specified values
  conform!(env, env_s())
  Map.put(env, :user_id, "User ID")
  env
end

def run(middleware \\ []) do
  # Magically get the env. We could pull the values from a plug conn or some other location.
  env = build_env()
  env = Enum.reduce(middleware, env, fn m, prev_env -> m.(prev_env) end)

  # We still want to ensure that our data is there but we don't want to discard the users data.
  env = conform!(env, env_s())
end

run([&user_middleware/1])
```

In our example the user's function can add arbitrary fields to the `env` map. Once the middleware has run we want to ensure that we haven't lost our specified fields, but we don't want to remove the other fields the user has added. The current design limits our ability to handle this case.

The other problem is around optionality. There's not a good way to say that a key is optional in a given context. Selections don't help us here since they only limit the conformed output. In practice this means that users end up having to specify a number of different schemas for different use cases instead of being able to re-use existing schemas.

## Solutions

I've thought about these problems for a while and I think I've arrived at a good path forward. After this PR schema and selection will return the entire input payload so long as any specified keys conform correctly. This makes Norm much more open to growth and supports the specific problems I described above.

In order to support optional keys, all the keys in a schema will now be optional. That means that all of these scenarios would be considered valid:

```elixir
user_schema = schema(%{
  name: spec(is_binary()),
  age: spec(is_integer()),
  email: spec(is_binary())
})
iex> valid?(%{}, user_schema)
true
iex> valid?(%{name: "chris"}, user_schema)
true
iex> valid?(%{name: "chris", age: 31}, user_schema)
true
iex> valid?(%{age: 31, other_key: "other"}, user_schema)
true
```

In order to mark certain fields as required we can use `selection`. Selection's will ensure that at least the keys specified are present.

```elixir
user_schema = schema(%{
  name: spec(is_binary()),
  age: spec(is_integer()),
  email: spec(is_binary())
})
iex> valid?(%{}, selection(user_schema, [:name])
false
iex> valid?(%{name: "chris"}, selection(user_schema, [:name]))
true
iex> valid?(%{name: "chris", age: 31}, selection(user_schema, [:name]))
true
```

If you want to mark all fields in all schema's as required, recursively, I've also provided a shorthand. Instead of specifying lists of keys you can use the single arity version of `selection` like so:

```elixir
schema = schema(%{
  a: spec(is_binary()),
  b: spec(is_binary()),
  c: spec(is_binary())
})
iex> valid?(%{}, selection(schema))
false
iex> valid?(%{a: "a", b: "b", c: "c"}, selection(schema))
true
```

Since selections no longer limit the returned values this effectively solves the optionality problem I described above. These semantics should allow us to support many more use cases and should increase the usability of schema's and selections.

## Future work

After these changes I'm beginning to think that the name `selection` no longer makes sense. Maybe something like `required` would be more meaningful. I'm going to think about that a bit more.