### PR TITLE
Use defoverridable and add reflection to Norm.Contract

### DIFF
--- a/lib/norm/contract.ex
+++ b/lib/norm/contract.ex
@@ -27,40 +27,29 @@ defmodule Norm.Contract do
 
   """
 
-  @doc false
-  def __before_compile__(env) do
-    contracts = Module.get_attribute(env.module, :norm_contracts)
-    definitions = Module.definitions_in(env.module)
-
-    for {fun, arity} <- contracts do
-      unless {:"__#{fun}_without_contract__", arity} in definitions do
-        raise ArgumentError, "contract for undefined function #{fun}/#{arity}"
-      end
-    end
-  end
+  defstruct [:args, :result]
 
   @doc false
   defmacro __using__(_) do
     quote do
-      import Kernel, except: [@: 1, def: 2]
-      import Norm.Contract
+      import Kernel, except: [@: 1]
       Module.register_attribute(__MODULE__, :norm_contracts, accumulate: true)
       @before_compile Norm.Contract
+      import Norm.Contract
     end
   end
 
   @doc false
-  defmacro def(call, expr) do
-    quote do
-      if unquote(fa(call)) in @norm_contracts do
-        unless Module.defines?(__MODULE__, unquote(fa(call))) do
-          Kernel.def(unquote(wrapper_call(call)), do: unquote(wrapper_body(call)))
-        end
+  defmacro __before_compile__(env) do
+    definitions = Module.definitions_in(env.module)
+    contracts = Module.get_attribute(env.module, :norm_contracts)
 
-        Kernel.def(unquote(call_without_contract(call)), unquote(expr))
-      else
-        Kernel.def(unquote(call), unquote(expr))
+    for {name, arity} <- contracts do
+      unless {name, arity} in definitions do
+        raise ArgumentError, "contract for undefined function #{name}/#{arity}"
       end
+
+      defconformer(name, arity)
     end
   end
 
@@ -75,94 +64,65 @@ defmodule Norm.Contract do
     end
   end
 
-  ## Internals
+  defp defconformer(name, arity) do
+    args =
+      List.duplicate(nil, arity)
+      |> Enum.with_index()
+      |> Enum.map(fn {_, index} -> Macro.var(:"arg#{index}", nil) end)
+
+    quote do
+      defoverridable [{unquote(name), unquote(arity)}]
+
+      def unquote(name)(unquote_splicing(args)) do
+        contract = __MODULE__.__contract__({unquote(name), unquote(arity)})
+
+        for {val, {_arg, spec}} <- Enum.zip(unquote(args), contract.args) do
+          Norm.conform!(val, spec)
+        end
+
+        result = super(unquote_splicing(args))
+        Norm.conform!(result, contract.result)
+        result
+      end
+    end
+  end
 
   defp defcontract(expr) do
     if Application.get_env(:norm, :enable_contracts, true) do
-      do_defcontract(expr)
-    end
-  end
+      {name, args, result} = parse_contract_expr(expr)
+      arity = length(args)
 
-  defp do_defcontract(expr) do
-    {call, result_spec} =
-      case expr do
-        [{:"::", _, [call, result_spec]}] ->
-          {call, result_spec}
-
-        _ ->
-          actual = Macro.to_string({:@, [], [{:contract, [], expr}]})
-
-          raise ArgumentError,
-                "contract must be in the form " <>
-                  "`@contract function(arg :: spec) :: result_spec`, got: `#{actual}`"
-      end
-
-    {name, call_meta, arg_specs} = call
-
-    arg_vars =
-      for arg_spec <- arg_specs do
-        case arg_spec do
-          {:"::", _, [{arg_name, _, _}, _spec]} ->
-            Macro.var(arg_name, nil)
-
-          _ ->
-            raise ArgumentError,
-                  "argument spec must be in the form `arg :: spec`, " <>
-                    "got: `#{Macro.to_string(arg_spec)}`"
+      quote do
+        @doc false
+        def __contract__({unquote(name), unquote(arity)}) do
+          %Norm.Contract{args: unquote(args), result: unquote(result)}
         end
-      end
 
-    conform_args =
-      for {:"::", _, [{arg_name, _, _}, spec]} <- arg_specs do
-        arg = Macro.var(arg_name, nil)
-
-        quote do
-          Norm.conform!(unquote(arg), unquote(spec))
-        end
-      end
-
-    conform_args = {:__block__, [], conform_args}
-    result = Macro.var(:result, nil)
-    call = {name, call_meta, arg_vars}
-
-    quote do
-      @norm_contracts unquote(fa(call))
-
-      def unquote(call_with_contract(call)) do
-        unquote(conform_args)
-        unquote(result) = unquote(call_without_contract(call))
-        Norm.conform!(unquote(result), unquote(result_spec))
-        unquote(result)
+        @norm_contracts {unquote(name), unquote(arity)}
       end
     end
   end
 
-  ## Utilities
-
-  defp wrapper_call(call) do
-    {name, meta, args} = call
-    args = for {_, index} <- Enum.with_index(args), do: Macro.var(:"arg#{index}", nil)
-    {name, meta, args}
+  defp parse_contract_expr([{:"::", _, [{name, _, args}, result]}]) do
+    args = Enum.map(args, &parse_arg/1)
+    {name, args, result}
   end
 
-  defp wrapper_body(call) do
-    {name, meta, args} = call
-    args = for {_, index} <- Enum.with_index(args), do: Macro.var(:"arg#{index}", nil)
-    {:"__#{name}_with_contract__", meta, args}
+  defp parse_contract_expr(expr) do
+    actual = Macro.to_string({:@, [], [{:contract, [], expr}]})
+
+    raise ArgumentError,
+          "contract must be in the form " <>
+            "`@contract function(arg :: spec) :: result_spec`, got: `#{actual}`"
   end
 
-  defp call_with_contract(call) do
-    {name, meta, args} = call
-    {:"__#{name}_with_contract__", meta, args}
+  defp parse_arg({:"::", _, [{name, _, _}, spec]}) do
+    {name, spec}
   end
 
-  defp call_without_contract(call) do
-    {name, meta, args} = call
-    {:"__#{name}_without_contract__", meta, args}
-  end
-
-  defp fa(call) do
-    {name, _meta, args} = call
-    {name, length(args)}
+  defp parse_arg(expr) do
+    raise ArgumentError,
+          "argument spec must be in the form `arg :: spec`, " <>
+            "got: `#{Macro.to_string(expr)}`"
   end
 end

--- a/test/norm/contract_test.exs
+++ b/test/norm/contract_test.exs
@@ -69,4 +69,20 @@ defmodule Norm.ContractTest do
       end
     end
   end
+
+  test "reflection" do
+    defmodule Reflection do
+      use Norm
+
+      def int(), do: spec(is_integer())
+
+      @contract foo(a :: int(), b :: int()) :: int()
+      def foo(a, b), do: a + b
+    end
+
+    contract = Reflection.__contract__({:foo, 2})
+
+    assert inspect(contract) ==
+             "%Norm.Contract{args: [a: #Norm.Spec<is_integer()>, b: #Norm.Spec<is_integer()>], result: #Norm.Spec<is_integer()>}"
+  end
 end


### PR DESCRIPTION
This is arguably simpler impelementation where we do less
metaprogramming by leveraging defoverridable.

Instead of overriding Kernel.def/2, we let the function be defined as
usual and we later simply defoverridable it with the contract conforming
function.

Additionally we add contract reflection, that is for each contract there
would be a `__contract__({fun, arity})` clause defined on the module.
This could be later used as a building block for things like:

    iex> contract = Foo.__contract__({:add, 2})
    iex> Norm.Contract.conform!(contract, {Bar, :bar, ["1", 2]})
    ** (Norm.MismatchError) Could not conform input:
    val: 42 fails: is_binary()
    iex> Norm.Contract.conform!(contract, {Bar, :bar, [1, 2]})
    3

but currently it's just an implementation detail. The reflection
function is not yet documented and is considered private API.