### PR TITLE
Fix handling of 0-arity def without parens

### DIFF
--- a/lib/norm/contract.ex
+++ b/lib/norm/contract.ex
@@ -139,14 +139,17 @@ defmodule Norm.Contract do
 
   ## Utilities
 
+  defp fix_call_parens({name, meta, nil}), do: {name, meta, []}
+  defp fix_call_parens({name, meta, args}), do: {name, meta, args}
+
   defp wrapper_call(call) do
-    {name, meta, args} = call
+    {name, meta, args} = fix_call_parens(call)
     args = for {_, index} <- Enum.with_index(args), do: Macro.var(:"arg#{index}", nil)
     {name, meta, args}
   end
 
   defp wrapper_body(call) do
-    {name, meta, args} = call
+    {name, meta, args} = fix_call_parens(call)
     args = for {_, index} <- Enum.with_index(args), do: Macro.var(:"arg#{index}", nil)
     {:"__#{name}_with_contract__", meta, args}
   end
@@ -162,7 +165,7 @@ defmodule Norm.Contract do
   end
 
   defp fa(call) do
-    {name, _meta, args} = call
+    {name, _meta, args} = fix_call_parens(call)
     {name, length(args)}
   end
 end


### PR DESCRIPTION
Fixes #54 

I started with extra clauses on `wrapper_call/1`, `wrapper_body/1`, and `fa/1`, but read the rest of your code and figured you might prefer more explicit code. Your tests and Credo remain happy.