### PR TITLE
Fixes Norm.Contract breaking on modules containing functions without parentheses

### DIFF
--- a/lib/norm/contract.ex
+++ b/lib/norm/contract.ex
@@ -51,6 +51,7 @@ defmodule Norm.Contract do
 
   @doc false
   defmacro def(call, expr) do
+    call = normalize_call(call)
     quote do
       if unquote(fa(call)) in @norm_contracts do
         unless Module.defines?(__MODULE__, unquote(fa(call))) do
@@ -165,4 +166,7 @@ defmodule Norm.Contract do
     {name, _meta, args} = call
     {name, length(args)}
   end
+
+  defp normalize_call({name, meta, nil}), do: {name, meta, []}
+  defp normalize_call({name, meta, args}), do: {name, meta, args}
 end

--- a/test/norm/contract_test.exs
+++ b/test/norm/contract_test.exs
@@ -69,4 +69,35 @@ defmodule Norm.ContractTest do
       end
     end
   end
+
+  test "function definition without parentheses" do
+    defmodule WithoutParentheses do
+      use Norm
+
+      @contract fun() :: spec(is_integer())
+      def fun do
+        42
+      end
+    end
+
+    assert WithoutParentheses.fun() == 42
+  end
+
+  test "non-contract function definition without parentheses" do
+    defmodule WithoutParentheses2 do
+      use Norm
+
+      @contract fun(int :: spec(is_integer())) :: spec(is_integer())
+      def fun(int) do
+        int * 2
+      end
+
+      def other do
+        "Hello, world!"
+      end
+    end
+
+    assert WithoutParentheses2.fun(50) == 100
+    assert WithoutParentheses2.other() == "Hello, world!"
+  end
 end


### PR DESCRIPTION
Fixes #64 by adding:

- A call-normalization step in Norm.Contract.def
- Tests for modules that have functions without parentheses.