### PR TITLE
Fix formatting error with missing keys

### DIFF
--- a/lib/norm/errors.ex
+++ b/lib/norm/errors.ex
@@ -56,7 +56,9 @@ defmodule Norm.SpecError do
   end
   defp format(atom, _) when is_atom(atom), do: ":#{atom}"
   defp format(str, _) when is_binary(str), do: ~s|"#{str}"|
-  defp format(%Spec{predicate: pred}, _), do: "spec(#{pred})"
+  defp format(%Spec{}=s, _), do: inspect(s)
+  defp format(%Spec.And{}=s, _), do: inspect(s)
+  defp format(%Spec.Or{}=s, _), do: inspect(s)
   defp format(%Schema{specs: specs}, i) do
     f = fn {key, spec_or_schema}, i ->
       format(key, i) <> " => " <> format(spec_or_schema, i + 1)
@@ -98,6 +100,9 @@ defmodule Norm.SpecError do
     else
       "one_of([])"
     end
+  end
+  defp format(val, i) do
+    inspect(val)
   end
 
   defp pad(str, 0), do: str

--- a/test/norm/core/selection_test.exs
+++ b/test/norm/core/selection_test.exs
@@ -112,6 +112,11 @@ defmodule Norm.Core.SelectionTest do
         })
         selection(users, [:other])
       end
+
+      assert_raise Norm.SpecError, fn ->
+        s = schema(%{count: spec(is_integer() and (& &1 > 0) or is_binary)})
+        selection(s, [:incorrect_key])
+      end
     end
 
     test "works with structs" do


### PR DESCRIPTION
There was a bug where if a key was missing, but the existing keys had
specs which also included `and` or `or` we would raise an exception
since we weren't formatting those correctly. Closes #48 