### PR TITLE
[Proposal] Add validation messages to Specs

### DIFF
--- a/lib/norm.ex
+++ b/lib/norm.ex
@@ -150,6 +150,10 @@ defmodule Norm do
     Spec.build(predicate)
   end
 
+  defmacro spec(predicate, message) do
+    Spec.build(predicate, message)
+  end
+
   @doc ~S"""
   Creates a re-usable schema. Schema's are open which means that all keys are
   optional and any non-specified keys are passed through without being conformed.

--- a/lib/norm/conformer.ex
+++ b/lib/norm/conformer.ex
@@ -3,6 +3,21 @@ defmodule Norm.Conformer do
   # This module provides an api for conforming values and a protocol for
   # conformable types
 
+  def conform(specs, input) when is_list(specs) do
+    Enum.reduce(specs, {}, fn s, acc ->
+      case acc do
+        {} ->
+          Norm.Conformer.Conformable.conform(s, input, [])
+
+        {:ok, _} ->
+          Norm.Conformer.Conformable.conform(s, input, [])
+
+        {:error, e} ->
+          {:error, e}
+      end
+    end)
+  end
+
   def conform(spec, input) do
     Norm.Conformer.Conformable.conform(spec, input, [])
   end
@@ -15,8 +30,12 @@ defmodule Norm.Conformer do
     |> update_in([:error], &List.flatten(&1))
   end
 
-  def error(path, input, msg) do
-    %{path: path, input: input, spec: msg}
+  def error(path, input, spec_msg) do
+    %{path: path, input: input, spec: spec_msg}
+  end
+
+  def error(path, input, spec_msg, validation_msg) do
+    %{path: path, input: input, spec: spec_msg, message: validation_msg}
   end
 
   def error_to_msg(%{path: path, input: input, spec: msg}) do

--- a/test/norm/core/spec_test.exs
+++ b/test/norm/core/spec_test.exs
@@ -7,6 +7,40 @@ defmodule Norm.Core.SpecTest do
     def match?(x, given), do: x == given
   end
 
+  describe "WIP - spec/2" do
+    test "WIP - can include validation messages" do
+      is_binary_spec = spec(is_binary(), "is not binary")
+
+      {:error, [error]} = conform(1, is_binary_spec)
+
+      assert error.message == "is not binary"
+    end
+
+    test "WIP - can chain specs and their validation messages" do
+      # NOTE: This isn't really a concern of the Spec module but I want to keep things centralized for this POC
+      is_string_spec = [
+        spec(is_binary(), "is not binary"),
+        spec(&(String.length(&1) > 1), "must have more than 2 characters")
+      ]
+
+      {:error, [error]} = conform("", is_string_spec)
+
+      assert error.message == "must have more than 2 characters"
+    end
+
+    test "WIP - chained specs fail fast to not invoke following specs" do
+      # NOTE: This isn't really a concern of the Spec module but I want to keep things centralized for this POC
+      really_bad_spec = [
+        spec(&(&1 && false), "I didn't like that"),
+        spec(&(&1 && raise ""), "I really won't like this")
+      ]
+
+      {:error, [error]} = conform("", really_bad_spec)
+
+      assert error.message == "I didn't like that"
+    end
+  end
+
   describe "spec/1" do
     test "can compose specs with 'and'" do
       hex = spec(is_binary() and (&String.starts_with?(&1, "#")))


### PR DESCRIPTION
Context: https://github.com/keathley/norm/issues/76

## Problem statement
Norm provides fantastic validation utilities but the errors generated aren't end-user friendly, leading to a split in our validation tooling.  In order to use Norm for validation across our stack we'd need the ability to have human-readable errors generated while supporting localization.

## Design goals
**Clarity**
Supplied validation messages should be specific to a logical validation unit. A message should give context about a failure rather than serving as a catch-all statement.

**Compatibility**
Validation messages should be opt-in and should not break existing implementations.

**Validation safety**
Specs should fail fast so that potentially invalid data isn't fed to further specs for the same attribute.

## Attempted approaches
**Return tuples**
A spec can now optionally return a tuple of `{boolean(), String.t()}` where `boolean()` is the result of the validation and `String.t()` is a validation message. 

This approach created ugly specs (think `spec(&({String.length(&1) > 0, "must not be blank}))`), didn't work for built-ins like `is_integer`, and made validation message composition very difficult.

**Per-spec messages**
A spec can optionally accept a second argument of a validation message.  This solves the shortcomings of the above approach, but fails on the design goal of clarity. To address this, I've added the ability to create a chained spec from a series of simpler specs. This is the approach I ended up going with.

## Proposed approach
### API

```elixir
integer_spec = spec(is_integer, "must be an integer")
conform(1, integer_spec) # {:ok, 1}
conform("", integer_spec) # {:error, %{ ... message: "must be an integer" ...}}

safe_spec = [
  spec(is_binary, "must be a binary"),
  spec(&(String.length(&1) > 0), "can't be blank")
]
conform(1, safe_spec) # `1` would cause `String.length` to blow up, but since it fails fast this never happens
conform("", safe_spec) # {:error, %{ ... message: "can't be blank" ...}}

good_messages_spec = [
  spec(is_binary, "must be a string"),
  spec(&(String.length(&1) in 3..15, "must be between 3 and 15 characters"),
  spec(&(!String.contains(&1, "heck")), "can't contain any forbidden words")
]

# Untested
schema(%User{
  username: [
    spec(is_binary),
    spec(&(String.length(&1) in 3..15, "must be between 3 and 15 characters")
  ],
  email: spec(at_symbol_spec, "must contain a @"),
  age: spec(is_integer)
})
```
### Upsides
- Clear validation messages
- Subjectively clear API
- Supports localization
- Mostly backward-compatible (see "downsides")
- Specs fail fast, returning the first error

### Downsides
**Seemingly ambiguous syntax**
Based on some pattern matching features of Norm as well as pattern matching with Elixir in general, you might write a spec like this:

```elixir
list_spec = [
  spec(is_binary),
  spec(is_integer),
  spec(is_atom)
]

conform(["", 1, :wow], list_spec) # Seems that a pattern matching-like approach would work here
```
However, this isn't the case.

**Chained specs are exclusively "and"**
Norm supports `and`/`or` for composing specs.  While these are supported within a single spec in the chain, the individual specs are treated with "and" logic.  Example:

```elixir
chained_spec = [
  spec(is_binary),
  spec(&(String.length(&1) > 0))
]
# is _mostly_ equivalent to:
spec(is_binary and &(String.length(&1) > 0))
```
This means you can't have `or` logic between elements on a chained spec.

In practice I've found this to be both logically clear and desirable, but I'm use there's a use case that would be negatively impacted by this.

**Not 100% backward-compatible**
Even if you don't use a message, the `message` key still exists in the returned error struct with a value of `nil`.  While this doesn't modify any logic or names within the error struct, strict pattern matching checks could fail. This is compounded by the fact that Norm, being a validation library, allows people to confidently check for the exact structure of a validation response in their tests or even their application code.

I'm sure there's a path forward here, but it isn't addressed in this initial POC.

## Wrapping up
This PR is meant to be both a low-effort code change and a discussion around different approaches and their pros + cons.

The code changes work as outlined, but some tests need to be updated (due to that backwards-compatibility issue) and many more tests need to be written if there's interest in this approach.