### PR TITLE
Fixes problems in the build order of `norm` with `stream_data`.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Norm.MixProject do
   defp deps do
     [
       {:credo, "~> 1.4", only: [:dev, :test], runtime: false},
-      {:stream_data, "~> 0.5", optional: true, only: [:dev, :test]},
+      {:stream_data, "~> 0.5", optional: true},
       {:ex_doc, "~> 0.19", only: [:dev, :test]}
     ]
   end


### PR DESCRIPTION
Turns out that configuring an optional dependency to be only used in certain environments is not the right way to do it.

This change should resolve problems in the compilation order of Norm + StreamData.

c.f.
https://github.com/keathley/norm/issues/46
and https://github.com/elixir-lang/elixir/issues/10099

