### PR TITLE
Adds `delegate/1` which allows late-binding (and therefore recursion)

### DIFF
--- a/lib/norm.ex
+++ b/lib/norm.ex
@@ -16,6 +16,7 @@ defmodule Norm do
     Schema,
     Selection,
     Spec,
+    Delegate
   }
 
   @doc false
@@ -148,6 +149,10 @@ defmodule Norm do
   """
   defmacro spec(predicate) do
     Spec.build(predicate)
+  end
+
+  def delegate(predicate) do
+    Delegate.build(predicate)
   end
 
   @doc ~S"""

--- a/lib/norm.ex
+++ b/lib/norm.ex
@@ -151,6 +151,16 @@ defmodule Norm do
     Spec.build(predicate)
   end
 
+  @doc ~S"""
+  Allows encapsulation of a spec in another function. This enables late-binding of
+  specs which enables definition of recursive specs.
+
+  ## Examples:
+      iex> conform!(%{"value" => 1, "left" => %{"value" => 2, "right" => %{"value" => 4}}}, Norm.Core.DelegateTest.TreeTest.spec())
+      %{"value" => 1, "left" => %{"value" => 2, "right" => %{"value" => 4}}}
+      iex> conform(%{"value" => 1, "left" => %{"value" => 2, "right" => %{"value" => 4, "right" => %{"value" => "12"}}}}, Norm.Core.DelegateTest.TreeTest.spec())
+      {:error, [%{input: "12", path: ["left", "right", "right", "value"], spec: "is_integer()"}]}
+  """
   def delegate(predicate) do
     Delegate.build(predicate)
   end

--- a/lib/norm/core/delegate.ex
+++ b/lib/norm/core/delegate.ex
@@ -1,4 +1,6 @@
 defmodule Norm.Core.Delegate do
+  @moduledoc false
+
   defstruct [:fun]
 
   def build(fun) when is_function(fun, 0) do

--- a/lib/norm/core/delegate.ex
+++ b/lib/norm/core/delegate.ex
@@ -1,0 +1,13 @@
+defmodule Norm.Core.Delegate do
+  defstruct [:fun]
+
+  def build(fun) when is_function(fun, 0) do
+    %__MODULE__{fun: fun}
+  end
+
+  defimpl Norm.Conformer.Conformable do
+    def conform(%{fun: fun}, input, path) do
+      Norm.Conformer.Conformable.conform(fun.(), input, path)
+    end
+  end
+end

--- a/test/norm/core/delegate_test.exs
+++ b/test/norm/core/delegate_test.exs
@@ -1,0 +1,30 @@
+defmodule Norm.Core.DelegateTest do
+  use Norm.Case, async: true
+
+  defmodule Foo do
+    def spec() do
+      schema(%{"level" => spec(is_integer()), "foo" => delegate(&Foo.spec/0)})
+    end
+  end
+
+  describe "delegate/1" do
+    test "can write recursive specs with 'delegate'" do
+      assert {:ok, _} = conform(%{}, Foo.spec())
+      assert {:ok, _} = conform(%{"level" => 3}, Foo.spec())
+
+      assert {:ok, _} = conform(%{"level" => 3, "foo" => %{"level" => 4}}, Foo.spec())
+
+      assert {:ok, _} =
+               conform(
+                 %{"level" => 3, "foo" => %{"level" => 4, "foo" => %{"level" => 5}}},
+                 Foo.spec()
+               )
+
+      assert {:error, [%{path: ["foo", "foo", "level"], spec: "is_integer()"}]} =
+               conform(
+                 %{"level" => 3, "foo" => %{"level" => 4, "foo" => %{"level" => "5"}}},
+                 Foo.spec()
+               )
+    end
+  end
+end


### PR DESCRIPTION
This should fix #36. I wasn't sure what to call it, but it appears to work (see the tests) and it's a very small addition.

I think this is what we should be wanting?

Anyways, let me know if you have any thoughts on this. I'm happy to change things around if necessary.