### PR TITLE
Add recommended combinations of Elixir and Erlang/OTP versions to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,24 +6,44 @@ jobs:
   credo:
     name: Credo
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: 1.9.x
+            otp: 20.3.8.26
+          - elixir: 1.10.x
+            otp: 21.3.8.18
+          - elixir: 1.11.x
+            otp: 21.3.8.18
+          - elixir: 1.11.x
+            otp: 23.1.1
+            warnings_as_errors: true
+            static_analysis: true
+    env:
+      MIX_ENV: test
+
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
         uses: actions/setup-elixir@v1
         with:
-          otp-version: 22.1
-          elixir-version: 1.9.4
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
 
-      - run: mix deps.get
-      - run: mix compile
+      - run: mix deps.get --only test
+      - run: mix format --check-formatted
+        if: matrix.static_analysis
+      - run: mix compile --warnings-as-errors
+        if: matrix.warnings_as_errors
       - run: mix credo
 
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
         uses: actions/setup-elixir@v1

--- a/test/norm/core/schema_test.exs
+++ b/test/norm/core/schema_test.exs
@@ -175,7 +175,7 @@ defmodule Norm.Core.SchemaTest do
 
     test "allows defaults" do
       spec = schema(%Movie{})
-      assert movie = conform(%Movie{}, spec)
+      assert conform(%Movie{}, spec)
     end
 
     property "can generate proper structs" do

--- a/test/norm_test.exs
+++ b/test/norm_test.exs
@@ -263,7 +263,7 @@ defmodule NormTest do
       assert {:error, _errors} = conform([{:foo, :bar} | list], spec)
 
       assert list == conform!(list, coll_of(opts, [min_count: 2, distinct: true]))
-      assert {:error, errors} = conform([], coll_of(opts, [min_count: 2, distinct: true]))
+      assert {:error, _errors} = conform([], coll_of(opts, [min_count: 2, distinct: true]))
     end
 
     property "can be generated" do


### PR DESCRIPTION
This pull request makes sure all recommended Elixir and Erlang/OTP combinations are run on CI.

Quoting José Valim:
> I would still advise folks to go with:
> * For each Elixir version, add a run with earliest supported Erlang/OTP
> * For the last Elixir version, also test the latest supported Erlang/OTP

Please refer to the original discussion on https://github.com/dashbitco/broadway/pull/188 for the full rationale.

Additional functionality: make sure there are no compilation warnings and checks formatting.

In case one wonders why not use `otp: N.x` for OTP as well as for Elixir, please refer to https://github.com/actions/setup-elixir/issues/45.